### PR TITLE
feat: add stripe payments controller

### DIFF
--- a/controllers/stripe.controller.mjs
+++ b/controllers/stripe.controller.mjs
@@ -1,0 +1,29 @@
+import Stripe from "stripe";
+
+class StripeController {
+  constructor(secretKey) {
+    this.secretKey = secretKey;
+  }
+
+  postPaymentIntent = async (request, response) => {
+    const stripe = new Stripe(this.secretKey);
+    const amount = request.body.amount;
+
+    try {
+      const paymentIntent = await stripe.paymentIntents.create({
+        amount,
+        currency: "sgd",
+      });
+
+      response.status(200).json({
+        client_secret: paymentIntent.client_secret,
+        message: "sucessfully created payment intent",
+      });
+    } catch (err) {
+      console.log(err);
+      response.status(500).json({ statusCode: 500, message: err.message });
+    }
+  };
+}
+
+export default StripeController;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "nodemon": "^2.0.20",
         "pg": "^8.8.0",
         "sequelize": "^6.23.0",
-        "sequelize-cli": "^6.4.1"
+        "sequelize-cli": "^6.4.1",
+        "stripe": "^10.12.0"
       }
     },
     "node_modules/@types/debug": {
@@ -1797,6 +1798,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/stripe": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-10.12.0.tgz",
+      "integrity": "sha512-4ijMsbTVSy6rzWIkal+/dFGeTXtjqLeZ/oo/jc2jhICbf3Dby0CBTPxAg6ZhBPXQL96TJxI613C/NhhE7LvrWw==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.10.3"
+      },
+      "engines": {
+        "node": "^8.1 || >=10.*"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3370,6 +3383,15 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
         "ansi-regex": "^5.0.1"
+      }
+    },
+    "stripe": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-10.12.0.tgz",
+      "integrity": "sha512-4ijMsbTVSy6rzWIkal+/dFGeTXtjqLeZ/oo/jc2jhICbf3Dby0CBTPxAg6ZhBPXQL96TJxI613C/NhhE7LvrWw==",
+      "requires": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.10.3"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "nodemon": "^2.0.20",
     "pg": "^8.8.0",
     "sequelize": "^6.23.0",
-    "sequelize-cli": "^6.4.1"
+    "sequelize-cli": "^6.4.1",
+    "stripe": "^10.12.0"
   }
 }

--- a/routes.mjs
+++ b/routes.mjs
@@ -1,6 +1,7 @@
 import db from "./db/models/index.mjs";
 import initUsersController from "./controllers/users.controller.mjs";
 import initOrdersController from "./controllers/orders.controller.mjs";
+import initStripeController from "./controllers/stripe.controller.mjs";
 
 export default function routes(app) {
   // users routes
@@ -12,4 +13,9 @@ export default function routes(app) {
   // orders routes
   const ordersController = new initOrdersController(db, usersController);
   app.post("/api/orders", ordersController.postNewOrder);
+
+  // stripe routes
+  const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+  const stripeController = new initStripeController(STRIPE_SECRET_KEY);
+  app.post("/api/stripe/payment-intents", stripeController.postPaymentIntent);
 }


### PR DESCRIPTION
## Changes
- add stripe payments controller (to work in tandem with [FE PR](https://github.com/Nyx92/3D-Model-Ecommerce-Frontend/pull/6)
- calls stripe api to create a payment intent

## How to test
- in .env file add `STRIPE_SECRET_KEY=<secret_value>` (refer to slack)

## Known Issues
- api call to orders endpoint not made yet will do so in another PR

## Screenshots (if any)
- Screenshots of features, before/after