### PR TITLE
feat: models seed data

### DIFF
--- a/db/migrations/20220929155704-create-tables.js
+++ b/db/migrations/20220929155704-create-tables.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  }
+};

--- a/db/seeders/20220929155712-seed-data.js
+++ b/db/seeders/20220929155712-seed-data.js
@@ -1,0 +1,33 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const modelData = [
+      {
+        model_name: "Clicky",
+        model_description:
+          "A fidget gadget for when your fingers are itching to make something move.",
+        model_group: "toys",
+        price_per_unit: 15,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+      {
+        model_name: "Spiral Planter Pot",
+        model_description: "A simple pot for cacti and other houseplants",
+        model_group: "home",
+        price_per_unit: 10,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ];
+
+    const [clickyModel] = await queryInterface.bulkInsert("models", modelData, {
+      returning: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("models", null, {});
+  },
+};


### PR DESCRIPTION
## Changes
- added seed file for models table to contain price and description info for 2 sample models

## How to test
- re-run all migrations and seeds:
```
npx sequelize db:migrate:undo:all
npx sequelize db:migrate 
npx sequelize db:seed:all
```
- check that the following tables are created:
  - models 
  - orders
  - users

- check that the models table contains seeded data - view all table contents with `SELECT * FROM models;`

## Known Issues
- N/A

## Screenshots (if any)
- expected tables:
![image](https://user-images.githubusercontent.com/47405262/195128070-6b9ecd52-8885-4d0d-bae4-6c1911d42e4f.png)

- expected seed data in models table:
![image](https://user-images.githubusercontent.com/47405262/195128241-ed6b45f1-ce54-496e-92f9-1083cb242cce.png)
